### PR TITLE
Monowrapper

### DIFF
--- a/services/scooter_service/package-lock.json
+++ b/services/scooter_service/package-lock.json
@@ -8,7 +8,8 @@
             "name": "scooter_service",
             "version": "1.0.0",
             "dependencies": {
-                "eslint-plugin-jest": "^27.1.6"
+                "eslint-plugin-jest": "^27.1.6",
+                "mongodb": "^4.12.1"
             },
             "devDependencies": {
                 "eslint": "^8.28.0",
@@ -30,6 +31,1371 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.110.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+            "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.226.0.tgz",
+            "integrity": "sha512-f97yYtFN2YyVLCkDM51yLakb5NKy9gTSSXWe9mA9rgynLPfgsJbIHXv3zr1Qg0Ay0p4j1eLYukLaVw1MKlHDgw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.226.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.226.0.tgz",
+            "integrity": "sha512-+Hl1YSLKrxPnQLijhWryI6uV8eKZIsUhvWlzFKx75kjxzjsC/jyk5zV59jnCu0SCCepXB8DKyLVa2WpH7iAHew==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.226.0.tgz",
+            "integrity": "sha512-IKzAhL6RoPs7IZ/rJvekjedQ4oesazCO+Aqh9l2Xct+XY0MFBdh4amgg4t/8fjksfIzmJH48BZoNv5gVak6yRw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.226.0.tgz",
+            "integrity": "sha512-ZBlqRVbnHvvbkN5g56+mXltNybHNzgV69+2ARubQ8ge9U2qF/LweCmGqZnZLWqdGXwaB9IOvz5ZW2npyJh1X/A==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-sdk-sts": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.226.0.tgz",
+            "integrity": "sha512-0UWXtfnTT0OtnRP8jJodc8V7xAnWSqsh4RCRyV5uu3Z2Tv+xyW91GKxO+gOXoUP0hHu0lvBM9lYiMJcJWZYLYw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.226.0.tgz",
+            "integrity": "sha512-ukueK6kgTxvUX89oQBoArj7Oh0dYfkToHypnin08SHRZry9VNnK5IfSMO+Q1tXmxCnDtai1ejaAOny900OjMyg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+            "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+            "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.226.0.tgz",
+            "integrity": "sha512-Sj7SGl53qmKkD7wvgU0MSTyj8ho6A3tKVbadTHljVz60jiauTEM97Z1DIai6U3oPFVteaKqx7npc8ozeK6mKNg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.226.0.tgz",
+            "integrity": "sha512-kuOeiVmlhSyMC1Eix0pqHmb4EmpbMHrTw+9ObZbQ2bRXy05Q9fLA6SVBcI01bI1KVh7Qqz9i8ojOY3A2zscjyA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-ini": "3.226.0",
+                "@aws-sdk/credential-provider-process": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+            "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.226.0.tgz",
+            "integrity": "sha512-QSBeyOIAus4/8u/DeAstE8w/zw+F7PQohdB8JFP/BPaCfc8uKue4UkqqvQWRfm4VSEnHeXt037MDopmCpd98Iw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/token-providers": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+            "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.226.0.tgz",
+            "integrity": "sha512-oNkUBxlX0kmwt8jEyQAH7p5Tk1g9iWEKGGCTPPZ7A5RoZpmv83zT8ReZ/+QsSmJIWGb0zzraHMzKbmfMSeztZg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.226.0",
+                "@aws-sdk/client-sso": "3.226.0",
+                "@aws-sdk/client-sts": "3.226.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.226.0",
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-ini": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/credential-provider-process": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+            "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/querystring-builder": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+            "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+            "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+            "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-endpoint": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+            "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+            "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+            "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+            "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.226.0.tgz",
+            "integrity": "sha512-uMn4dSkv9Na2uvt6K3HgTnVrCRAlGv1MBAtUDLXONqUv1L/Z1fp3CkFkLKQHKylfBwBhe6dXfYEo87i8LZFoqg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/service-error-classification": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+            "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+            "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+            "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+            "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+            "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+            "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+            "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/querystring-builder": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+            "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+            "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+            "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+            "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.226.0.tgz",
+            "integrity": "sha512-9R01dBpE8JILe2CTft7YN2tMufT2mMWMTqxmHwPSmOpsxHTj8hEII7GTfvpb95ThHwW7XMNhg7pbHLbrTJZCVA==",
+            "optional": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+            "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+            "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
+            "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.226.0.tgz",
+            "integrity": "sha512-3ouRt2i3ve8ivg54PxPhtOTcipzf6BoQsMw0EiO23yYKujhyeFH2IkxV4EYC687xFrUjheqJf8FWU/DD8EQ/ow==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-sso-oidc": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+            "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+            "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-base64": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
+            "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.226.0.tgz",
+            "integrity": "sha512-Zr0AEj6g8gqiOhr31Pa2tdOFdPQciaAUCg3Uj/eH0znNBdVoptCj67oCW/I5v4pY4ZLZtGhr3uuoxDJH2MB3yg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
+            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-middleware": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+            "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+            "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.226.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+            "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
+        },
+        "node_modules/@aws-sdk/util-utf8-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-node/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "optional": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
@@ -1240,8 +2606,7 @@
         "node_modules/@types/node": {
             "version": "18.11.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-            "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
-            "dev": true
+            "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
         },
         "node_modules/@types/prettier": {
             "version": "2.7.1",
@@ -1259,6 +2624,20 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.15",
@@ -1666,6 +3045,25 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1674,6 +3072,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "optional": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1730,6 +3134,40 @@
             "dev": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/bson": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+            "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+            "dependencies": {
+                "buffer": "^5.6.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -2544,6 +3982,22 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
+        "node_modules/fast-xml-parser": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "optional": true,
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
+            }
+        },
         "node_modules/fastq": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -2893,6 +4347,25 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/ignore": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
@@ -2976,6 +4449,11 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -4024,6 +5502,12 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4077,6 +5561,32 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/mongodb": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.12.1.tgz",
+            "integrity": "sha512-koT87tecZmxPKtxRQD8hCKfn+ockEL2xBiUvx3isQGI6mFmagWt4f4AyCE9J4sKepnLhMacoCTQQA6SLAI2L6w==",
+            "dependencies": {
+                "bson": "^4.7.0",
+                "mongodb-connection-string-url": "^2.5.4",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=12.9.0"
+            },
+            "optionalDependencies": {
+                "@aws-sdk/credential-providers": "^3.186.0",
+                "saslprep": "^1.0.3"
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "dependencies": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
             }
         },
         "node_modules/ms": {
@@ -4753,6 +6263,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4836,6 +6358,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "dependencies": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4853,6 +6397,15 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "optional": true,
+            "dependencies": {
+                "memory-pager": "^1.0.2"
             }
         },
         "node_modules/sprintf-js": {
@@ -4977,6 +6530,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "optional": true
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5055,6 +6614,17 @@
             },
             "bin": {
                 "nodetouch": "bin/nodetouch.js"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/tsconfig-paths": {
@@ -5208,6 +6778,15 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "optional": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-to-istanbul": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -5235,6 +6814,26 @@
             "dev": true,
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "dependencies": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/which": {
@@ -5372,6 +6971,1320 @@
             "requires": {
                 "@jridgewell/gen-mapping": "^0.1.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@aws-crypto/ie11-detection": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "optional": true,
+            "requires": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "@aws-crypto/supports-web-crypto": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "optional": true,
+            "requires": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "@aws-crypto/util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "^3.110.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "@aws-sdk/abort-controller": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+            "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/client-cognito-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.226.0.tgz",
+            "integrity": "sha512-f97yYtFN2YyVLCkDM51yLakb5NKy9gTSSXWe9mA9rgynLPfgsJbIHXv3zr1Qg0Ay0p4j1eLYukLaVw1MKlHDgw==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.226.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/client-sso": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.226.0.tgz",
+            "integrity": "sha512-+Hl1YSLKrxPnQLijhWryI6uV8eKZIsUhvWlzFKx75kjxzjsC/jyk5zV59jnCu0SCCepXB8DKyLVa2WpH7iAHew==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/client-sso-oidc": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.226.0.tgz",
+            "integrity": "sha512-IKzAhL6RoPs7IZ/rJvekjedQ4oesazCO+Aqh9l2Xct+XY0MFBdh4amgg4t/8fjksfIzmJH48BZoNv5gVak6yRw==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/client-sts": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.226.0.tgz",
+            "integrity": "sha512-ZBlqRVbnHvvbkN5g56+mXltNybHNzgV69+2ARubQ8ge9U2qF/LweCmGqZnZLWqdGXwaB9IOvz5ZW2npyJh1X/A==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/fetch-http-handler": "3.226.0",
+                "@aws-sdk/hash-node": "3.226.0",
+                "@aws-sdk/invalid-dependency": "3.226.0",
+                "@aws-sdk/middleware-content-length": "3.226.0",
+                "@aws-sdk/middleware-endpoint": "3.226.0",
+                "@aws-sdk/middleware-host-header": "3.226.0",
+                "@aws-sdk/middleware-logger": "3.226.0",
+                "@aws-sdk/middleware-recursion-detection": "3.226.0",
+                "@aws-sdk/middleware-retry": "3.226.0",
+                "@aws-sdk/middleware-sdk-sts": "3.226.0",
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/middleware-user-agent": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/node-http-handler": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/smithy-client": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.226.0",
+                "@aws-sdk/util-defaults-mode-node": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-user-agent-browser": "3.226.0",
+                "@aws-sdk/util-user-agent-node": "3.226.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/config-resolver": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.226.0.tgz",
+            "integrity": "sha512-0UWXtfnTT0OtnRP8jJodc8V7xAnWSqsh4RCRyV5uu3Z2Tv+xyW91GKxO+gOXoUP0hHu0lvBM9lYiMJcJWZYLYw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.226.0.tgz",
+            "integrity": "sha512-ukueK6kgTxvUX89oQBoArj7Oh0dYfkToHypnin08SHRZry9VNnK5IfSMO+Q1tXmxCnDtai1ejaAOny900OjMyg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/client-cognito-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-env": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+            "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-imds": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+            "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-ini": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.226.0.tgz",
+            "integrity": "sha512-Sj7SGl53qmKkD7wvgU0MSTyj8ho6A3tKVbadTHljVz60jiauTEM97Z1DIai6U3oPFVteaKqx7npc8ozeK6mKNg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.226.0.tgz",
+            "integrity": "sha512-kuOeiVmlhSyMC1Eix0pqHmb4EmpbMHrTw+9ObZbQ2bRXy05Q9fLA6SVBcI01bI1KVh7Qqz9i8ojOY3A2zscjyA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-ini": "3.226.0",
+                "@aws-sdk/credential-provider-process": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-process": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+            "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-sso": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.226.0.tgz",
+            "integrity": "sha512-QSBeyOIAus4/8u/DeAstE8w/zw+F7PQohdB8JFP/BPaCfc8uKue4UkqqvQWRfm4VSEnHeXt037MDopmCpd98Iw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/client-sso": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/token-providers": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+            "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/credential-providers": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.226.0.tgz",
+            "integrity": "sha512-oNkUBxlX0kmwt8jEyQAH7p5Tk1g9iWEKGGCTPPZ7A5RoZpmv83zT8ReZ/+QsSmJIWGb0zzraHMzKbmfMSeztZg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/client-cognito-identity": "3.226.0",
+                "@aws-sdk/client-sso": "3.226.0",
+                "@aws-sdk/client-sts": "3.226.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.226.0",
+                "@aws-sdk/credential-provider-env": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/credential-provider-ini": "3.226.0",
+                "@aws-sdk/credential-provider-node": "3.226.0",
+                "@aws-sdk/credential-provider-process": "3.226.0",
+                "@aws-sdk/credential-provider-sso": "3.226.0",
+                "@aws-sdk/credential-provider-web-identity": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/fetch-http-handler": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+            "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/querystring-builder": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/hash-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+            "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/invalid-dependency": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+            "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/is-array-buffer": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-content-length": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+            "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-endpoint": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+            "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/middleware-serde": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/url-parser": "3.226.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-host-header": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+            "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-logger": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+            "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+            "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-retry": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.226.0.tgz",
+            "integrity": "sha512-uMn4dSkv9Na2uvt6K3HgTnVrCRAlGv1MBAtUDLXONqUv1L/Z1fp3CkFkLKQHKylfBwBhe6dXfYEo87i8LZFoqg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/service-error-classification": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+            "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/middleware-signing": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-serde": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+            "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-signing": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+            "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/signature-v4": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-stack": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+            "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/middleware-user-agent": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+            "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/node-config-provider": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+            "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/node-http-handler": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+            "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/abort-controller": "3.226.0",
+                "@aws-sdk/protocol-http": "3.226.0",
+                "@aws-sdk/querystring-builder": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/property-provider": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+            "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/protocol-http": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+            "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/querystring-builder": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+            "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/querystring-parser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+            "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/service-error-classification": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.226.0.tgz",
+            "integrity": "sha512-9R01dBpE8JILe2CTft7YN2tMufT2mMWMTqxmHwPSmOpsxHTj8hEII7GTfvpb95ThHwW7XMNhg7pbHLbrTJZCVA==",
+            "optional": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+            "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/signature-v4": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+            "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-middleware": "3.226.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/smithy-client": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
+            "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/middleware-stack": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/token-providers": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.226.0.tgz",
+            "integrity": "sha512-3ouRt2i3ve8ivg54PxPhtOTcipzf6BoQsMw0EiO23yYKujhyeFH2IkxV4EYC687xFrUjheqJf8FWU/DD8EQ/ow==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/client-sso-oidc": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/shared-ini-file-loader": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/types": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+            "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/url-parser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+            "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/querystring-parser": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-base64": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-body-length-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-body-length-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-buffer-from": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-config-provider": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
+            "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.226.0.tgz",
+            "integrity": "sha512-Zr0AEj6g8gqiOhr31Pa2tdOFdPQciaAUCg3Uj/eH0znNBdVoptCj67oCW/I5v4pY4ZLZtGhr3uuoxDJH2MB3yg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/config-resolver": "3.226.0",
+                "@aws-sdk/credential-provider-imds": "3.226.0",
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/property-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-endpoints": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
+            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-hex-encoding": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-locate-window": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-middleware": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+            "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-uri-escape": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+            "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.226.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-user-agent-node": {
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+            "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.226.0",
+                "@aws-sdk/types": "3.226.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-utf8-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "optional": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
+            }
+        },
+        "@aws-sdk/util-utf8-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "optional": true
+                }
             }
         },
         "@babel/code-frame": {
@@ -6326,8 +9239,7 @@
         "@types/node": {
             "version": "18.11.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-            "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
-            "dev": true
+            "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
         },
         "@types/prettier": {
             "version": "2.7.1",
@@ -6345,6 +9257,20 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+        },
+        "@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "requires": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
         },
         "@types/yargs": {
             "version": "17.0.15",
@@ -6625,11 +9551,22 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "optional": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -6667,6 +9604,23 @@
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "bson": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+            "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+            "requires": {
+                "buffer": "^5.6.0"
+            }
+        },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "buffer-from": {
@@ -7270,6 +10224,15 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
+        "fast-xml-parser": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "optional": true,
+            "requires": {
+                "strnum": "^1.0.5"
+            }
+        },
         "fastq": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -7516,6 +10479,11 @@
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
         "ignore": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
@@ -7575,6 +10543,11 @@
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             }
+        },
+        "ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -8345,6 +11318,12 @@
                 "tmpl": "1.0.5"
             }
         },
+        "memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8384,6 +11363,27 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
             "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
             "dev": true
+        },
+        "mongodb": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.12.1.tgz",
+            "integrity": "sha512-koT87tecZmxPKtxRQD8hCKfn+ockEL2xBiUvx3isQGI6mFmagWt4f4AyCE9J4sKepnLhMacoCTQQA6SLAI2L6w==",
+            "requires": {
+                "@aws-sdk/credential-providers": "^3.186.0",
+                "bson": "^4.7.0",
+                "mongodb-connection-string-url": "^2.5.4",
+                "saslprep": "^1.0.3",
+                "socks": "^2.7.1"
+            }
+        },
+        "mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "requires": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
+            }
         },
         "ms": {
             "version": "2.1.2",
@@ -8848,6 +11848,15 @@
                 "is-regex": "^1.1.4"
             }
         },
+        "saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "requires": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8912,6 +11921,20 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
+        "smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+        },
+        "socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "requires": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+            }
+        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8926,6 +11949,15 @@
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "optional": true,
+            "requires": {
+                "memory-pager": "^1.0.2"
             }
         },
         "sprintf-js": {
@@ -9019,6 +12051,12 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "optional": true
+        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9076,6 +12114,14 @@
             "dev": true,
             "requires": {
                 "nopt": "~1.0.10"
+            }
+        },
+        "tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "requires": {
+                "punycode": "^2.1.1"
             }
         },
         "tsconfig-paths": {
@@ -9181,6 +12227,12 @@
                 "punycode": "^2.1.0"
             }
         },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "optional": true
+        },
         "v8-to-istanbul": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -9207,6 +12259,20 @@
             "dev": true,
             "requires": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "requires": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
             }
         },
         "which": {

--- a/services/scooter_service/package.json
+++ b/services/scooter_service/package.json
@@ -17,6 +17,7 @@
         "nodemon": "^2.0.15"
     },
     "dependencies": {
-        "eslint-plugin-jest": "^27.1.6"
+        "eslint-plugin-jest": "^27.1.6",
+        "mongodb": "^4.12.1"
     }
 }

--- a/services/scooter_service/src/scooter_handler.js
+++ b/services/scooter_service/src/scooter_handler.js
@@ -1,0 +1,204 @@
+const { MongoWrapper } = require('../../../shared/mongowrapper');
+const scooters = require('../../../shared/dummy_data/scooter_service/scooters');
+
+
+
+
+class ScooterHandler {
+    constructor() {
+      return this.#init();
+    }
+
+    async #init() {
+      this.db = await new MongoWrapper("scoooooooooters");
+      return this;
+    }
+
+    async test() {
+      const newScooter = {
+        scooterId: await this.db.getNextId("scoooooooooters", "scooterId"),
+        status: "inactive",
+        userId: 0,
+        properties: {
+            location: "goteborg",
+            lat: 43.43434,
+            lng: 65.655656,
+            speed: 0,
+            battery: 100
+        },
+        log: []
+      }
+
+      const insertedObj = await this.db.insertOne("scoooooooooters", newScooter);
+
+      console.log(await this.db.find("scoooooooooters"));
+
+    }
+  
+    // TODO: db/options
+    getScooters(options = {}) {
+      let result = this.scooters;
+  
+      
+      if (options.hasOwnProperty('location')) {
+        result = result.filter((scooter) => {
+          return scooter.properties.location === options.location;
+        });
+      }
+  
+      
+  
+      if (options.hasOwnProperty('scooterId')) {
+        result = result.filter((scooter) => {
+          return scooter.scooterId === options.scooterId;
+        });
+      }
+  
+      return result;
+    }
+  
+    addScooter(newScooterInfo) {
+      const newScooter = {
+        scooterId: 500,
+        status: "inactive",
+        userId: 0,
+        properties: {
+            location: newScooterInfo.location,
+            lat: newScooterInfo.lat,
+            lng: newScooterInfo.lng,
+            speed: 0,
+            battery: 100
+        },
+        log: []
+      }
+  
+      this.scooters.push(newScooter);
+  
+      return newScooter;
+    }
+  
+    // TODO
+    updateScooter(updatedScooter) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === updatedScooter.scooterId) {
+  
+          if (updatedScooter.hasOwnProperty('status')) {
+            scooter.status = updatedScooter.status;
+          }
+          if (updatedScooter.hasOwnProperty('location')) {
+              scooter.properties.location = updatedScooter.location;
+          }
+          if (updatedScooter.hasOwnProperty('lat')) {
+              scooter.properties.lat = updatedScooter.lat;
+          }
+          if (updatedScooter.hasOwnProperty('lng')) {
+              scooter.properties.lng = updatedScooter.lng;
+          }
+  
+          return scooter;
+        }
+      }
+      
+    }
+  
+    removeScooter(scooterId) {
+      for (let i = 0; i < this.scooters.length; i++) {
+        if (this.scooters[i].scooterId === scooterId) {
+          const removedScooter = this.scooters.splice(i, 1)[0];
+          return removedScooter;
+        }
+      }
+    }
+    
+    /**
+     * Unlock scooter: change info and return scooter data.
+     * @param {number} scooterId 
+     * @param {number} userId 
+     * @returns {object}
+     */
+    unlockScooter(scooterId, userId) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === scooterId) {
+          scooter.status = "claimed";
+          scooter.userId = userId;
+          return scooter;
+        }
+      }
+    }
+  
+    /**
+     * Scooter unlocked: change info and return scooter data.
+     * @param {object} unlockedScooter 
+     * @returns {object}
+     */
+    scooterUnlocked(unlockedScooter) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === unlockedScooter.scooterId) {
+          scooter.status = unlockedScooter.status;
+          scooter.userId = unlockedScooter.userId;
+          console.log(`Scooter ${scooter.scooterId} unlocked`)
+          return scooter;
+        }
+      }
+    }
+  
+    /**
+     * Lock scooter. Change info and return scooter data.
+     * @param {number} scooterId 
+     * @returns {object}
+     */
+    lockScooter(scooterId) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === scooterId) {
+          scooter.status = "available";
+          scooter.userId = 0;
+          return scooter;
+        }
+      }
+    }
+  
+    /**
+     * Scooter locked. Change info and return locked scooter.
+     * @param {object} lockedScooter 
+     * @returns 
+     */
+    scooterLocked(lockedScooter) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === lockedScooter.scooterId) {
+          scooter.status = lockedScooter.status;
+          scooter.userId = lockedScooter.userId;
+          console.log(`Scooter ${scooter.scooterId} locked`)
+          return scooter;
+        }
+      }
+    }
+  
+    /**
+     * Update scooter position info
+     * @param {number} scooterId 
+     * @param {object} position 
+     * @returns {boolean}
+     */
+    updateScooterPosition(scooterId, position) {
+      for (const scooter of this.scooters) {
+        if (scooter.scooterId === scooterId) {
+          scooter.properties.lat = position.lat;
+          scooter.properties.lng = position.lng;
+          console.log(`Scooter ${scooter.scooterId} at lat: ${scooter.properties.lat} lng: ${scooter.properties.lng}.`)
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+  
+  const test = async () => {
+    const sh = await new ScooterHandler();
+
+    await sh.test();
+  }
+
+  test();
+
+  
+  //module.exports = { ScooterHandler };

--- a/shared/mongowrapper.js
+++ b/shared/mongowrapper.js
@@ -4,114 +4,142 @@ const mongo = require("mongodb").MongoClient;
 /**
  * A class for creating MongoDB wrapper objects.
  */
-class mongowrapper {
-    /**
-     * Creates a MongoDB wrapper object.
-     * @param {Object} client - A MongoClient object.
-     */
-    constructor() {
-      this.client;
-      this.url = "mongodb://mongodb:27017/mydb"
-    }
+class MongoWrapper {
+  /**
+   * Creates a MongoDB wrapper object.
+   */
+  constructor(dbName) {
+    return this.#connectClient();
+  }
 
-    async connectClient(){
-      try {
-        const client = await mongo.connect(this.url, { useNewUrlParser: true,
-        useUnifiedTopology: true, });
-        this.client = client;
-        return client;
-      } catch(e) {
-            return {
-                errors: {
-                    message: "could not connect to mongo",
-                }
-            };
-      }
-    }
+  /**
+   * Initiate, used to get around constructor async limitations.
+   * @returns {object}
+   */
+  async #connectClient(dbName){
+    this.url = "mongodb://mongodb:27017/mydb";
+    this.dbName = dbName;
 
-
-    /**
-     * Gets a collection from MongoDB.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @returns {Object} - The collection.
-     */
-    async getCollection(dbName, collectionName) {
-      const db = this.client.db(dbName);
-      return db.collection(collectionName);
-    }
-
-    /**
-     * Inserts a document into a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @param {Object} document - The document to insert.
-     * @returns {Object} - The result of the insert operation.
-     */
-    async insertOne(dbName, collectionName, document) {
-      const collection = await this.getCollection(dbName, collectionName);
-      return collection.insertOne(document);
-    }
-
-    /**
-     * Inserts many documents into a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @param {Array} arrayOfDocuments - array with objects
-     * @returns {Object} - The result of the insert operation.
-     */
-    async insertMany(dbName, collectionName, arrayOfDocuments) {
-        const collection = await this.getCollection(dbName, collectionName);
-        return collection.insertMany(arrayOfDocuments);
-      }
-
-    /**
-     * updates one document into a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @param {string} objectId - MongoDB Object id of object to be updated
-     * @param {Object} update - Object to be updated
-     * @returns {Object} - The result of the insert operation.
-     */
-    async updateOne(dbName, collectionName, objectId, update) {
-      const collection = await this.getCollection(dbName, collectionName);
-      return collection.updateOne( {"_id" : ObjectID(objectId._id)}, {$set: update});
-    }
-
-    /**
-     * updates one document into a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @param {Object} deleteObject - Object to be deleted
-     * @returns {Object} - The result of the insert operation.
-     */
-    async deleteOne(dbName, collectionName, deleteObject) {
-      const collection = await this.getCollection(dbName, collectionName);
-      return collection.deleteOne( { "_id" : ObjectID(deleteObject._id) });
-    }
-
-    /**
-     * Gets all documents from a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @returns {Object[]} - The documents.
-     */
-    async find(dbName, collectionName) {
-      const collection = await this.getCollection(dbName, collectionName);
-      return collection.find({}).toArray();
-    }
-
-    /**
-     * updates one document into a collection.
-     * @param {string} dbName - The name of the database.
-     * @param {string} collectionName - The name of the collection.
-     * @param {Object} findObject - Object to be found
-     * @returns {Object} - The result of the insert operation.
-     */
-    async findOne(dbName, collectionName, findObject) {
-      const collection = await this.getCollection(dbName, collectionName);
-      return collection.findOne( { "_id" : ObjectID(findObject._id) });
+    try {
+      const client = await mongo.connect(this.url, { useNewUrlParser: true,
+      useUnifiedTopology: true, });
+      this.client = client;
+      return this;
+    } catch(e) {
+        return {
+          errors: {
+            message: "could not connect to mongo",
+          }
+        };
     }
   }
 
-  module.exports = { mongowrapper }
+
+  /**
+   * Gets a collection from MongoDB.
+   * @param {string} collectionName - The name of the collection.
+   * @returns {object} - The collection.
+   */
+  async getCollection(collectionName) {
+    const db = this.client.db(this.dbName);
+    return db.collection(collectionName);
+  }
+
+  async getNextId(collectionName, idName) {
+    const counterCollectionName = collectionName + "Counter";
+    const collection = await this.getCollection(counterCollectionName);
+
+    const lastId = await collection.findOne( { "_id" : idName });
+
+    if (lastId === null) {
+      const newId = {
+        _id: idName,
+        seq: 0
+      };
+  
+      collection.insertOne(newId);
+  
+      return newId.seq;
+    }
+    
+    collection.deleteOne({ _id: lastId._id });
+    const newId = {
+      _id: idName,
+      seq: lastId.seq + 1
+    };
+
+    collection.insertOne(newId);
+
+    return newId.seq;
+
+  }
+
+  /**
+   * Inserts a document into a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @param {object} document - The document to insert.
+   * @returns {object} - The result of the insert operation.
+   */
+  async insertOne(collectionName, document, idName) {
+    const collection = await this.getCollection(collectionName);
+    return collection.insertOne(document);
+  }
+
+  /**
+   * Inserts many documents into a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @param {Array} arrayOfDocuments - array with objects
+   * @returns {Object} - The result of the insert operation.
+   */
+  async insertMany(collectionName, arrayOfDocuments) {
+    const collection = await this.getCollection(collectionName);
+    return collection.insertMany(arrayOfDocuments);
+  }
+
+  /**
+   * updates one document into a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @param {string} objectId - MongoDB Object id of object to be updated
+   * @param {Object} update - Object to be updated
+   * @returns {Object} - The result of the insert operation.
+   */
+  async updateOne(collectionName, objectId, update) {
+    const collection = await this.getCollection(collectionName);
+    return collection.updateOne( {"_id" : ObjectID(objectId._id)}, {$set: update});
+  }
+
+  /**
+   * updates one document into a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @param {Object} deleteObject - Object to be deleted
+   * @returns {Object} - The result of the insert operation.
+   */
+  async deleteOne(dbName, collectionName, deleteObject) {
+    const collection = await this.getCollection(collectionName);
+    return collection.deleteOne( { "_id" : ObjectID(deleteObject._id) });
+  }
+
+  /**
+   * Gets all documents from a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @returns {Object[]} - The documents.
+   */
+  async find(collectionName) {
+    const collection = await this.getCollection(collectionName);
+    return collection.find({}).toArray();
+  }
+
+  /**
+   * gets one document from a collection.
+   * @param {string} collectionName - The name of the collection.
+   * @param {Object} query - What to query for
+   * @param {Object} projection - Filters out fields if field=1 then print if 0 no print
+   * @returns {Object} - The result of the insert operation.
+   */
+  async findOne(collectionName, query, projection = {}) {
+    const collection = await this.getCollection(collectionName);
+    return collection.findOne(query, projection);
+}
+}
+
+  module.exports = { MongoWrapper }

--- a/shared/mongowrapper.js
+++ b/shared/mongowrapper.js
@@ -80,7 +80,7 @@ class MongoWrapper {
    * @param {object} document - The document to insert.
    * @returns {object} - The result of the insert operation.
    */
-  async insertOne(collectionName, document, idName) {
+  async insertOne(collectionName, document) {
     const collection = await this.getCollection(collectionName);
     return collection.insertOne(document);
   }


### PR DESCRIPTION
- Tog bort dbName som parameter (kändes onödigt att skriva wrapper.insertOne("scooters", "scooters", obj) vaaarje gång.
- Fixade till connetClient - målet är ju att få en wrapper som fungerar i våra användningsfall, finns ingen anledning att jag explicit måste kalla på connectClient. Nu sker det i konstruktorn.
- La till en funktion för att få ett unikt inkrementerande id:
Används typ så här:

const newScooter = {
        scooterId: await this.db.getNextId("scoooooooooters", "scooterId"),
        status: "inactive",
        ....
      }
Alltså man bestämmer ett namn på id, t ex scooterId eller userId. Sedan börjar den räkna från 0 helt enkelt. _id finns fortfarande kvar internt i databasen. Resultatet blir så här:

{
    _id: new ObjectId("6395b0fe1edb755eb26d9408"),
    scooterId: 22,
    status: 'inactive',
    userId: 0,
    properties: {
      location: 'goteborg',
      lat: 43.43434,
      lng: 65.655656,
      speed: 0,
      battery: 100
    },
    log: []
  }